### PR TITLE
Update symmetric.jl

### DIFF
--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -33,9 +33,11 @@ Finds necessary values to find symmetric Nash equilibrium
 """
 function find_symmetric_nash_equilibrium_2players_game(game::Dict{String,<:AbstractArray},
                s::Array{SymPy.Sym,1})
+    n = size(game["player1"])[1]
+    id_m = Matrix(1I, n, n)
     res = 0
-    for i in eachrow(game["player1"])
-        res = res + max(get_payoff(game, [map(x->sympify(x),i), s])["player1"] - get_payoff(game, [s, s])["player1"], 0)^2
+    for i in 1:n
+        res = res + max(get_payoff(game, [map(x->sympify(x), id_m[i, :]), s])["player1"] - get_payoff(game, [s, s])["player1"], 0)^2
     end
     return find_zeros(res, 0, 1)
 end


### PR DESCRIPTION
`find_symmetric_nash_equilibrium_2players_game` now takes rows of identity matrix (representing pure strategies) for `res` calculation, instead of rows of payoff matrix.

Consulted with dr Ramsza.